### PR TITLE
Add machine name to u-boot/bootloader cm-fx6-evk.conf

### DIFF
--- a/conf/machine/cm-fx6-evk.conf
+++ b/conf/machine/cm-fx6-evk.conf
@@ -9,8 +9,8 @@ require conf/machine/include/tune-cortexa9.inc
 
 SOC_FAMILY = "mx6:mx6q"
 
-PREFERRED_PROVIDER_u_boot = "u-boot-compulab"
-PREFERRED_PROVIDER_virtual/bootloader = "u-boot-compulab"
+PREFERRED_PROVIDER_u_boot_cm-fx6-evk = "u-boot-compulab"
+PREFERRED_PROVIDER_virtual/bootloader_cm-fx6-evk = "u-boot-compulab"
 PREFERRED_PROVIDER_virtual/kernel_cm-fx6-evk = "linux-compulab"
 
 do_rootfs[depends] += "u-boot-script-compulab:do_deploy"


### PR DESCRIPTION
Add the target machine name to the preferred u-boot/bootloader provider name. 
It allows the build system issues a correct u-boot recipe.