### PR TITLE
Add machine name to u-boot/bootloader cl-som-imx6ul.conf

### DIFF
--- a/conf/machine/cl-som-imx6ul.conf
+++ b/conf/machine/cl-som-imx6ul.conf
@@ -10,8 +10,8 @@ include conf/machine/include/imx6ul-common.inc
 
 SOC_FAMILY = "mx6ul"
 
-PREFERRED_PROVIDER_u_boot = "u-boot-compulab"
-PREFERRED_PROVIDER_virtual/bootloader = "u-boot-compulab"
+PREFERRED_PROVIDER_u_boot_cl-som-imx6ul = "u-boot-compulab"
+PREFERRED_PROVIDER_virtual/bootloader_cl-som-imx6ul = "u-boot-compulab"
 PREFERRED_PROVIDER_virtual/kernel_cl-som-imx6ul = "linux-compulab"
 
 UBOOT_MACHINE ?= "cl_som_imx6ul_defconfig"


### PR DESCRIPTION
Add the target machine name to the preferred u-boot/bootloader provider name.
It allows the build system issues a correct u-boot recipe.